### PR TITLE
Update polynomial_traj.h

### DIFF
--- a/src/planner/traj_utils/include/traj_utils/polynomial_traj.h
+++ b/src/planner/traj_utils/include/traj_utils/polynomial_traj.h
@@ -231,8 +231,8 @@ public:
       /* jerk matrix */
       Eigen::MatrixXd mat_jerk(order, order);
       mat_jerk.setZero();
-      for (double i = 3; i < order; i += 1)
-        for (double j = 3; j < order; j += 1)
+      for (int i = 3; i < order; i += 1)
+        for (int j = 3; j < order; j += 1)
         {
           mat_jerk(i, j) =
               i * (i - 1) * (i - 2) * j * (j - 1) * (j - 2) * pow(ts, i + j - 5) / (i + j - 5);


### PR DESCRIPTION
234-235 行 for 循环的圆括号里面用了 double（应该是int），这会导致在某些特殊情况下编译不过。 
issue https://github.com/HKUST-Aerial-Robotics/Fast-Planner/issues/92  中遇到了同样的问题